### PR TITLE
OpenAPI v3 schema generator should handle nested and nullable types correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ TypeScript.
 Here's what you have to do:
 
 - Define your API using TypeScript types (see below).
-- Run `typescript-json-schema` to produce a JSON Schema for your API.
+- Run `ts-json-schema-generator` to produce a JSON Schema for your API.
 
 Here's what you get in return:
 
@@ -22,7 +22,7 @@ Requirements:
 - TypeScript 4.1+
 - Express
 
-There is an optional requirement of [`typescript-json-schema`][tsjs] if you
+There is an optional requirement of [`ts-json-schema-generator`][tsjs] if you
 want runtime request validation or API docs. (You probably do!)
 
 For a full example of a project using crosswalk, see this [demo repo][demo].
@@ -135,9 +135,9 @@ const fredSearchUrl = userUrl(null, {query: 'fred'});
 ## Runtime request validation
 
 To ensure that your users hit API endpoints with the correct payloads, use
-`typescript-json-schema` to convert your API definition to JSON Schema:
+`ts-json-schema-generator` to convert your API definition to JSON Schema:
 
-    typescript-json-schema --required --strictNullChecks --noExtraProps api.ts API --out api.schema.json
+    ts-json-schema-generator --no-ref-encode --no-top-ref --path api.ts API --out api.schema.json
 
 Then pass this to the `TypeRouter` when you create it in `server.ts`:
 
@@ -155,7 +155,7 @@ friendly error message:
     }
 
 You now have two representations of your API: `api.ts` and `api.schema.json`.
-The recommended way to keep them in sync is to run `typescript-json-schema` as
+The recommended way to keep them in sync is to run `ts-json-schema-generator` as
 part of your continuous integration workflow and fail if there are any diffs.
 The TypeScript definition (`api.ts`) is the source of truth, not the JSON
 Schema (`api.schema.json`).
@@ -293,7 +293,7 @@ friendlier to use. And you'd still need some way to get TypeScript types out
 of it to get static type checking.
 
 There are several tools for defining types that are available both at runtime
-and for TypeScript. If running `typescript-json-schema` bothers you, you might
+and for TypeScript. If running `ts-json-schema-generator` bothers you, you might
 want to look into [iots][] or [zod][].
 
 **How do I keep `api.ts` and `api.schema.json` in sync?**
@@ -328,16 +328,12 @@ If you get errors about `Type 'any' is not assignable to type 'never'.`, it
 might be because you're using an old version of TypeScript, either in your
 project or in your editor.
 
-**Should I set `noExtraProps` with `typescript-json-schema`?**
+**Should I set `--additional-properties` with `ts-json-schema-generator`?**
 
-There are many options you can set when you run [`typescript-json-schema`][tsjs]. You should think
+There are many options you can set when you run [`ts-json-schema-generator`][tsjs]. You should think
 carefully about these as they have an impact on the runtime behavior of your code.
 
-You should set `strictNullChecks` to whatever it's set to in your `tsconfig.json`. (It should
-really be set to `true`!). This ensures that the runtime checking and static type checking are in
-agreement.
-
-The `noExtraProps` option is more interesting. TypeScript uses a "structural" or "duck" typing
+The `--additional-properties` option is more interesting. TypeScript uses a "structural" or "duck" typing
 system. This means that an object may have the declared properties in its type, _but it could have
 others, too_!
 
@@ -355,15 +351,15 @@ getHeroDetails(superman);  // ok!
 ```
 
 This is simply the way that TypeScript works, and so it must be the way that crosswalk statically
-enforces your request types. If you're comfortable with this behavior, leave `noExtraProps` off.
+enforces your request types. If you're comfortable with this behavior, set `--additional-properties`.
 
-If you _do_ specify `noExtraProps`, additional properties on a request will result in the request
+If you _do not_ specify `--additional-properties`, additional properties on a request will result in the request
 being rejected at runtime with a 400 HTTP response. This has pros and cons. The pros are that it
 will catch more user errors (e.g. misspelling an optional property name) and allows the server to
 be more confident about the shape of its input (`Object.keys` won't produce surprises). The con
 is that your runtime behavior is divergent from the static type checking, so client code that
 passes the type checker might produce failing requests at runtime. Until TypeScript gets
-["exact" types][exact], it will not be able to fully model `noExtraProps` statically.
+["exact" types][exact], it will not be able to fully model `--additional-properties=false` statically.
 
 **What's with the name?**
 
@@ -400,7 +396,7 @@ To publish:
     yarn tsc
     yarn publish
 
-[tsjs]: https://github.com/YousefED/typescript-json-schema
+[tsjs]: https://github.com/vega/ts-json-schema-generator
 [ajv]: https://ajv.js.org/
 [1]: https://effectivetypescript.com/2020/07/27/safe-queryselector/
 [zod]: https://github.com/colinhacks/zod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crosswalk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Type-safe express routing with TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",
-    "update-test-schema": "typescript-json-schema --required --noExtraProps --strictNullChecks src/__tests__/api.ts API --out src/__tests__/api.schema.json"
+    "update-test-schema": "ts-json-schema-generator --no-ref-encode --no-top-ref --path src/__tests__/api.ts --type API --out src/__tests__/api.schema.json"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/express": "^5.0.1",
     "@types/jest": "^26.0.15",
+    "@types/node": "^22.15.30",
     "@types/supertest": "^2.0.10",
     "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
@@ -41,8 +42,8 @@
     "prettier": "^2.2.0",
     "supertest": "^6.0.1",
     "ts-jest": "^29.3.2",
-    "typescript": "5",
-    "typescript-json-schema": "^0.43.0"
+    "ts-json-schema-generator": "^2.4.0",
+    "typescript": "5"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/src/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/__tests__/__snapshots__/openapi.test.ts.snap
@@ -4,31 +4,96 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
 {
   "components": {
     "schemas": {
-      "Partial_Pick_User__name___age___": {
+      "Address": {
         "additionalProperties": false,
         "properties": {
-          "age": {
-            "type": "number",
-          },
-          "name": {
+          "city": {
             "type": "string",
           },
-        },
-        "type": "object",
-      },
-      "Pick_User__name___age__": {
-        "additionalProperties": false,
-        "properties": {
-          "age": {
-            "type": "number",
+          "location": {
+            "$ref": "#/components/schemas/Location",
           },
-          "name": {
+          "state": {
+            "type": "string",
+          },
+          "street": {
+            "type": "string",
+          },
+          "zip": {
             "type": "string",
           },
         },
         "required": [
-          "age",
+          "street",
+          "city",
+          "state",
+          "zip",
+          "location",
+        ],
+        "type": "object",
+      },
+      "CreateUserRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "age": {
+            "type": "number",
+          },
+          "name": {
+            "type": "string",
+          },
+          "permanentAddress": {
+            "$ref": "#/components/schemas/Address",
+          },
+          "phoneNumbers": {
+            "items": {
+              "$ref": "#/components/schemas/PhoneNumber",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
           "name",
+          "age",
+          "phoneNumbers",
+          "permanentAddress",
+        ],
+        "type": "object",
+      },
+      "Location": {
+        "additionalProperties": false,
+        "properties": {
+          "latitude": {
+            "type": "number",
+          },
+          "longitude": {
+            "type": "number",
+          },
+        },
+        "required": [
+          "latitude",
+          "longitude",
+        ],
+        "type": "object",
+      },
+      "PhoneNumber": {
+        "additionalProperties": false,
+        "properties": {
+          "number": {
+            "type": "string",
+          },
+          "type": {
+            "enum": [
+              "home",
+              "work",
+              "mobile",
+            ],
+            "nullable": true,
+            "type": "string",
+          },
+        },
+        "required": [
+          "number",
+          "type",
         ],
         "type": "object",
       },
@@ -44,14 +109,25 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
           "name": {
             "type": "string",
           },
+          "permanentAddress": {
+            "$ref": "#/components/schemas/Address",
+          },
+          "phoneNumbers": {
+            "items": {
+              "$ref": "#/components/schemas/PhoneNumber",
+            },
+            "type": "array",
+          },
           "suffix": {
             "type": "string",
           },
         },
         "required": [
-          "age",
           "id",
           "name",
+          "age",
+          "phoneNumbers",
+          "permanentAddress",
         ],
         "type": "object",
       },
@@ -81,11 +157,22 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
                   "name": {
                     "type": "string",
                   },
+                  "permanentAddress": {
+                    "$ref": "#/components/schemas/Address",
+                  },
+                  "phoneNumbers": {
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber",
+                    },
+                    "type": "array",
+                  },
                 },
                 "required": [
                   "age",
                   "id",
                   "name",
+                  "permanentAddress",
+                  "phoneNumbers",
                 ],
                 "type": "object",
               },
@@ -114,15 +201,8 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
                 "additionalProperties": false,
                 "properties": {
                   "user": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/User",
-                      },
-                      {
-                        "nullable": true,
-                        "type": "object",
-                      },
-                    ],
+                    "$ref": "#/components/schemas/User",
+                    "nullable": true,
                   },
                 },
                 "required": [
@@ -172,6 +252,51 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
           },
         },
         "summary": "Get a random number",
+      },
+    },
+    "/search": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "numResults",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "users": {
+                      "items": {
+                        "$ref": "#/components/schemas/User",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "users",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+          },
+        },
+        "summary": undefined,
       },
     },
     "/users": {
@@ -239,7 +364,7 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Pick_User__name___age__",
+                "$ref": "#/components/schemas/CreateUserRequest",
               },
             },
           },
@@ -332,7 +457,25 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Partial_Pick_User__name___age___",
+                "additionalProperties": false,
+                "properties": {
+                  "age": {
+                    "type": "number",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "permanentAddress": {
+                    "$ref": "#/components/schemas/Address",
+                  },
+                  "phoneNumbers": {
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber",
+                    },
+                    "type": "array",
+                  },
+                },
+                "type": "object",
               },
             },
           },
@@ -374,6 +517,15 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
                   "name": {
                     "type": "string",
                   },
+                  "permanentAddress": {
+                    "$ref": "#/components/schemas/Address",
+                  },
+                  "phoneNumbers": {
+                    "items": {
+                      "$ref": "#/components/schemas/PhoneNumber",
+                    },
+                    "type": "array",
+                  },
                 },
                 "type": "object",
               },
@@ -402,31 +554,99 @@ exports[`Open API V3 should have the expected endpoints: open-api-v3 1`] = `
 exports[`Open API integration should have the expected endpoints: open-api 1`] = `
 {
   "definitions": {
-    "Partial<Pick<User,"name"|"age">>": {
+    "Address": {
       "additionalProperties": false,
       "properties": {
-        "age": {
-          "type": "number",
-        },
-        "name": {
+        "city": {
           "type": "string",
         },
-      },
-      "type": "object",
-    },
-    "Pick<User,"name"|"age">": {
-      "additionalProperties": false,
-      "properties": {
-        "age": {
-          "type": "number",
+        "location": {
+          "$ref": "#/definitions/Location",
         },
-        "name": {
+        "state": {
+          "type": "string",
+        },
+        "street": {
+          "type": "string",
+        },
+        "zip": {
           "type": "string",
         },
       },
       "required": [
-        "age",
+        "street",
+        "city",
+        "state",
+        "zip",
+        "location",
+      ],
+      "type": "object",
+    },
+    "CreateUserRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "age": {
+          "type": "number",
+        },
+        "name": {
+          "type": "string",
+        },
+        "permanentAddress": {
+          "$ref": "#/definitions/Address",
+        },
+        "phoneNumbers": {
+          "items": {
+            "$ref": "#/definitions/PhoneNumber",
+          },
+          "type": "array",
+        },
+      },
+      "required": [
         "name",
+        "age",
+        "phoneNumbers",
+        "permanentAddress",
+      ],
+      "type": "object",
+    },
+    "Location": {
+      "additionalProperties": false,
+      "properties": {
+        "latitude": {
+          "type": "number",
+        },
+        "longitude": {
+          "type": "number",
+        },
+      },
+      "required": [
+        "latitude",
+        "longitude",
+      ],
+      "type": "object",
+    },
+    "PhoneNumber": {
+      "additionalProperties": false,
+      "properties": {
+        "number": {
+          "type": "string",
+        },
+        "type": {
+          "enum": [
+            "home",
+            "work",
+            "mobile",
+            null,
+          ],
+          "type": [
+            "string",
+            "null",
+          ],
+        },
+      },
+      "required": [
+        "number",
+        "type",
       ],
       "type": "object",
     },
@@ -442,14 +662,25 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
         "name": {
           "type": "string",
         },
+        "permanentAddress": {
+          "$ref": "#/definitions/Address",
+        },
+        "phoneNumbers": {
+          "items": {
+            "$ref": "#/definitions/PhoneNumber",
+          },
+          "type": "array",
+        },
         "suffix": {
           "type": "string",
         },
       },
       "required": [
-        "age",
         "id",
         "name",
+        "age",
+        "phoneNumbers",
+        "permanentAddress",
       ],
       "type": "object",
     },
@@ -478,11 +709,22 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
                 "name": {
                   "type": "string",
                 },
+                "permanentAddress": {
+                  "$ref": "#/definitions/Address",
+                },
+                "phoneNumbers": {
+                  "items": {
+                    "$ref": "#/definitions/PhoneNumber",
+                  },
+                  "type": "array",
+                },
               },
               "required": [
                 "age",
                 "id",
                 "name",
+                "permanentAddress",
+                "phoneNumbers",
               ],
               "type": "object",
             },
@@ -557,6 +799,47 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
         "summary": "Get a random number",
       },
     },
+    "/search": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "numResults",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "query",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "schema": {
+              "additionalProperties": false,
+              "properties": {
+                "users": {
+                  "items": {
+                    "$ref": "#/definitions/User",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "users",
+              ],
+              "type": "object",
+            },
+          },
+        },
+        "summary": undefined,
+      },
+    },
     "/users": {
       "get": {
         "parameters": [
@@ -603,7 +886,7 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
             "in": "body",
             "name": "body",
             "schema": {
-              "$ref": "#/definitions/Pick<User,"name"|"age">",
+              "$ref": "#/definitions/CreateUserRequest",
             },
           },
           {
@@ -644,7 +927,7 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
             "in": "body",
             "name": "body",
             "schema": {
-              "properties": {},
+              "additionalProperties": false,
               "type": "object",
             },
           },
@@ -695,7 +978,25 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
             "in": "body",
             "name": "body",
             "schema": {
-              "$ref": "#/definitions/Partial<Pick<User,"name"|"age">>",
+              "additionalProperties": false,
+              "properties": {
+                "age": {
+                  "type": "number",
+                },
+                "name": {
+                  "type": "string",
+                },
+                "permanentAddress": {
+                  "$ref": "#/definitions/Address",
+                },
+                "phoneNumbers": {
+                  "items": {
+                    "$ref": "#/definitions/PhoneNumber",
+                  },
+                  "type": "array",
+                },
+              },
+              "type": "object",
             },
           },
         ],
@@ -727,6 +1028,15 @@ exports[`Open API integration should have the expected endpoints: open-api 1`] =
                 },
                 "name": {
                   "type": "string",
+                },
+                "permanentAddress": {
+                  "$ref": "#/definitions/Address",
+                },
+                "phoneNumbers": {
+                  "items": {
+                    "$ref": "#/definitions/PhoneNumber",
+                  },
+                  "type": "array",
                 },
               },
               "type": "object",

--- a/src/__tests__/api.schema.json
+++ b/src/__tests__/api.schema.json
@@ -1,408 +1,592 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "additionalProperties": false,
-    "definitions": {
-        "Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User,null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "$ref": "#/definitions/Partial<Pick<User,\"name\"|\"age\">>"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "Address": {
+      "additionalProperties": false,
+      "properties": {
+        "city": {
+          "type": "string"
         },
-        "Endpoint<Pick<User,\"name\"|\"age\">&{id:string;},User,null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "age": {
-                            "type": "number"
-                        },
-                        "id": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "age",
-                        "id",
-                        "name"
-                    ],
-                    "type": "object"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
+        "location": {
+          "$ref": "#/definitions/Location"
         },
-        "Endpoint<Pick<User,\"name\"|\"age\">,User,{nameIncludes?:string|undefined;suffix?:string|undefined;}>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "nameIncludes": {
-                            "type": "string"
-                        },
-                        "suffix": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "request": {
-                    "$ref": "#/definitions/Pick<User,\"name\"|\"age\">"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
+        "state": {
+          "type": "string"
         },
-        "Endpoint<{name?:string|undefined;age?:number|undefined;},User,null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "age": {
-                            "type": "number"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
+        "street": {
+          "type": "string"
         },
-        "Endpoint<{user:User|null;},User,null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "user": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/definitions/User"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ]
-                        }
-                    },
-                    "required": [
-                        "user"
-                    ],
-                    "type": "object"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
-        },
-        "Endpoint<{},User,null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "properties": {
-                    },
-                    "type": "object"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
-        },
-        "GetEndpoint<User,{firstName?:string|undefined;}>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "firstName": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "request": {
-                    "type": "null"
-                },
-                "response": {
-                    "$ref": "#/definitions/User"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
-        },
-        "GetEndpoint<{random:number;},null>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "type": "null"
-                },
-                "request": {
-                    "type": "null"
-                },
-                "response": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "random": {
-                            "type": "number"
-                        }
-                    },
-                    "required": [
-                        "random"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
-        },
-        "GetEndpoint<{users:User[];},{nameIncludes?:string|undefined;minAge?:number|undefined;}>": {
-            "additionalProperties": false,
-            "properties": {
-                "query": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "minAge": {
-                            "type": "number"
-                        },
-                        "nameIncludes": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                "request": {
-                    "type": "null"
-                },
-                "response": {
-                    "additionalProperties": false,
-                    "properties": {
-                        "users": {
-                            "items": {
-                                "$ref": "#/definitions/User"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    "required": [
-                        "users"
-                    ],
-                    "type": "object"
-                }
-            },
-            "required": [
-                "query",
-                "request",
-                "response"
-            ],
-            "type": "object"
-        },
-        "Partial<Pick<User,\"name\"|\"age\">>": {
-            "additionalProperties": false,
-            "properties": {
-                "age": {
-                    "type": "number"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "Pick<User,\"name\"|\"age\">": {
-            "additionalProperties": false,
-            "properties": {
-                "age": {
-                    "type": "number"
-                },
-                "name": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "age",
-                "name"
-            ],
-            "type": "object"
-        },
-        "User": {
-            "additionalProperties": false,
-            "properties": {
-                "age": {
-                    "type": "number"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "suffix": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "age",
-                "id",
-                "name"
-            ],
-            "type": "object"
+        "zip": {
+          "type": "string"
         }
+      },
+      "required": [
+        "street",
+        "city",
+        "state",
+        "zip",
+        "location"
+      ],
+      "type": "object"
     },
-    "properties": {
-        "/complex": {
-            "additionalProperties": false,
-            "properties": {
-                "patch": {
-                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">&{id:string;},User,null>"
-                },
-                "post": {
-                    "$ref": "#/definitions/Endpoint<{user:User|null;},User,null>"
-                }
-            },
-            "required": [
-                "patch",
-                "post"
-            ],
-            "type": "object"
+    "CreateUserRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "age": {
+          "type": "number"
         },
-        "/random": {
-            "additionalProperties": false,
-            "properties": {
-                "get": {
-                    "$ref": "#/definitions/GetEndpoint<{random:number;},null>",
-                    "description": "Get a random number"
-                }
-            },
-            "required": [
-                "get"
-            ],
-            "type": "object"
+        "name": {
+          "type": "string"
         },
-        "/users": {
-            "additionalProperties": false,
-            "properties": {
-                "get": {
-                    "$ref": "#/definitions/GetEndpoint<{users:User[];},{nameIncludes?:string|undefined;minAge?:number|undefined;}>",
-                    "description": "Get the full list of users"
-                },
-                "post": {
-                    "$ref": "#/definitions/Endpoint<Pick<User,\"name\"|\"age\">,User,{nameIncludes?:string|undefined;suffix?:string|undefined;}>",
-                    "description": "Create a new user"
-                }
-            },
-            "required": [
-                "get",
-                "post"
-            ],
-            "type": "object"
+        "permanentAddress": {
+          "$ref": "#/definitions/Address"
         },
-        "/users/:userId": {
-            "additionalProperties": false,
-            "properties": {
-                "delete": {
-                    "$ref": "#/definitions/Endpoint<{},User,null>"
-                },
-                "get": {
-                    "$ref": "#/definitions/GetEndpoint<User,{firstName?:string|undefined;}>"
-                },
-                "patch": {
-                    "$ref": "#/definitions/Endpoint<Partial<Pick<User,\"name\"|\"age\">>,User,null>",
-                    "description": "Edit an existing user"
-                },
-                "put": {
-                    "$ref": "#/definitions/Endpoint<{name?:string|undefined;age?:number|undefined;},User,null>"
-                }
-            },
-            "required": [
-                "delete",
-                "get",
-                "patch",
-                "put"
-            ],
-            "type": "object"
+        "phoneNumbers": {
+          "items": {
+            "$ref": "#/definitions/PhoneNumber"
+          },
+          "type": "array"
         }
+      },
+      "required": [
+        "name",
+        "age",
+        "phoneNumbers",
+        "permanentAddress"
+      ],
+      "type": "object"
     },
-    "required": [
-        "/complex",
-        "/random",
-        "/users",
-        "/users/:userId"
-    ],
-    "type": "object"
+    "Endpoint<(def-alias-1619584020-201-306-1619584020-0-1730&structure-1619584020-1552-1565-1619584020-1533-1565-1619584020-1523-1572-1619584020-1433-1573-1619584020-1303-1577-1619584020-1289-1578-1619584020-591-1729-1619584020-0-1730),User>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "additionalProperties": false,
+          "properties": {
+            "age": {
+              "type": "number"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "permanentAddress": {
+              "$ref": "#/definitions/Address"
+            },
+            "phoneNumbers": {
+              "items": {
+                "$ref": "#/definitions/PhoneNumber"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "age",
+            "id",
+            "name",
+            "permanentAddress",
+            "phoneNumbers"
+          ],
+          "type": "object"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<CreateUserRequest,User,structure-1619584020-912-953-1619584020-878-954-1619584020-839-955-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "additionalProperties": false,
+          "properties": {
+            "nameIncludes": {
+              "type": "string"
+            },
+            "suffix": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "request": {
+          "$ref": "#/definitions/CreateUserRequest"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<alias-731470504-72960-73056-731470504-0-217694<def-alias-1619584020-201-306-1619584020-0-1730>,User>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "additionalProperties": false,
+          "properties": {
+            "age": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "permanentAddress": {
+              "$ref": "#/definitions/Address"
+            },
+            "phoneNumbers": {
+              "items": {
+                "$ref": "#/definitions/PhoneNumber"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<null,User,structure-1619584020-1009-1030-1619584020-991-1031-1619584020-982-1032-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "additionalProperties": false,
+          "properties": {
+            "firstName": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "request": {
+          "type": "null"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<null,structure-1619584020-1667-1682-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730,structure-1619584020-1683-1720-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "additionalProperties": false,
+          "properties": {
+            "numResults": {
+              "type": "number"
+            },
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "type": "object"
+        },
+        "request": {
+          "type": "null"
+        },
+        "response": {
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "items": {
+                "$ref": "#/definitions/User"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "users"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<null,structure-1619584020-683-699-1619584020-670-700-1619584020-630-701-1619584020-628-705-1619584020-615-706-1619584020-591-1729-1619584020-0-1730,null>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "type": "null"
+        },
+        "response": {
+          "additionalProperties": false,
+          "properties": {
+            "random": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "random"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<null,structure-1619584020-780-795-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730,structure-1619584020-796-837-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "additionalProperties": false,
+          "properties": {
+            "minAge": {
+              "type": "number"
+            },
+            "nameIncludes": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "request": {
+          "type": "null"
+        },
+        "response": {
+          "additionalProperties": false,
+          "properties": {
+            "users": {
+              "items": {
+                "$ref": "#/definitions/User"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "users"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<structure-1619584020-1139-1233-1619584020-1129-1251-1619584020-1120-1252-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730,User>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "additionalProperties": false,
+          "properties": {
+            "age": {
+              "type": "number"
+            },
+            "name": {
+              "type": "string"
+            },
+            "permanentAddress": {
+              "$ref": "#/definitions/Address"
+            },
+            "phoneNumbers": {
+              "items": {
+                "$ref": "#/definitions/PhoneNumber"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<structure-1619584020-1274-1276-1619584020-1264-1283-1619584020-1252-1284-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730,User>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "additionalProperties": false,
+          "type": "object"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "Endpoint<structure-1619584020-1406-1425-1619584020-1396-1432-1619584020-1305-1433-1619584020-1303-1577-1619584020-1289-1578-1619584020-591-1729-1619584020-0-1730,User>": {
+      "additionalProperties": false,
+      "properties": {
+        "query": {
+          "type": "null"
+        },
+        "request": {
+          "additionalProperties": false,
+          "properties": {
+            "user": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/User"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "user"
+          ],
+          "type": "object"
+        },
+        "response": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "request",
+        "response",
+        "query"
+      ],
+      "type": "object"
+    },
+    "GetEndpoint<User,structure-1619584020-1009-1030-1619584020-991-1031-1619584020-982-1032-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730>": {
+      "$ref": "#/definitions/Endpoint<null,User,structure-1619584020-1009-1030-1619584020-991-1031-1619584020-982-1032-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730>"
+    },
+    "GetEndpoint<structure-1619584020-1667-1682-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730,structure-1619584020-1683-1720-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730>": {
+      "$ref": "#/definitions/Endpoint<null,structure-1619584020-1667-1682-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730,structure-1619584020-1683-1720-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730>"
+    },
+    "GetEndpoint<structure-1619584020-683-699-1619584020-670-700-1619584020-630-701-1619584020-628-705-1619584020-615-706-1619584020-591-1729-1619584020-0-1730>": {
+      "$ref": "#/definitions/Endpoint<null,structure-1619584020-683-699-1619584020-670-700-1619584020-630-701-1619584020-628-705-1619584020-615-706-1619584020-591-1729-1619584020-0-1730,null>"
+    },
+    "GetEndpoint<structure-1619584020-780-795-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730,structure-1619584020-796-837-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>": {
+      "$ref": "#/definitions/Endpoint<null,structure-1619584020-780-795-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730,structure-1619584020-796-837-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>"
+    },
+    "Location": {
+      "additionalProperties": false,
+      "properties": {
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude"
+      ],
+      "type": "object"
+    },
+    "PhoneNumber": {
+      "additionalProperties": false,
+      "properties": {
+        "number": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "home",
+            "work",
+            "mobile",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "number",
+        "type"
+      ],
+      "type": "object"
+    },
+    "User": {
+      "additionalProperties": false,
+      "properties": {
+        "age": {
+          "type": "number"
+        },
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "permanentAddress": {
+          "$ref": "#/definitions/Address"
+        },
+        "phoneNumbers": {
+          "items": {
+            "$ref": "#/definitions/PhoneNumber"
+          },
+          "type": "array"
+        },
+        "suffix": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "age",
+        "phoneNumbers",
+        "permanentAddress"
+      ],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "/complex": {
+      "additionalProperties": false,
+      "properties": {
+        "patch": {
+          "$ref": "#/definitions/Endpoint<(def-alias-1619584020-201-306-1619584020-0-1730&structure-1619584020-1552-1565-1619584020-1533-1565-1619584020-1523-1572-1619584020-1433-1573-1619584020-1303-1577-1619584020-1289-1578-1619584020-591-1729-1619584020-0-1730),User>"
+        },
+        "post": {
+          "$ref": "#/definitions/Endpoint<structure-1619584020-1406-1425-1619584020-1396-1432-1619584020-1305-1433-1619584020-1303-1577-1619584020-1289-1578-1619584020-591-1729-1619584020-0-1730,User>"
+        }
+      },
+      "required": [
+        "post",
+        "patch"
+      ],
+      "type": "object"
+    },
+    "/random": {
+      "additionalProperties": false,
+      "properties": {
+        "get": {
+          "$ref": "#/definitions/GetEndpoint<structure-1619584020-683-699-1619584020-670-700-1619584020-630-701-1619584020-628-705-1619584020-615-706-1619584020-591-1729-1619584020-0-1730>",
+          "description": "Get a random number"
+        }
+      },
+      "required": [
+        "get"
+      ],
+      "type": "object"
+    },
+    "/search": {
+      "additionalProperties": false,
+      "properties": {
+        "get": {
+          "$ref": "#/definitions/GetEndpoint<structure-1619584020-1667-1682-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730,structure-1619584020-1683-1720-1619584020-1654-1721-1619584020-1593-1722-1619584020-1591-1726-1619584020-1578-1727-1619584020-591-1729-1619584020-0-1730>"
+        }
+      },
+      "required": [
+        "get"
+      ],
+      "type": "object"
+    },
+    "/users": {
+      "additionalProperties": false,
+      "properties": {
+        "get": {
+          "$ref": "#/definitions/GetEndpoint<structure-1619584020-780-795-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730,structure-1619584020-796-837-1619584020-767-838-1619584020-720-839-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>",
+          "description": "Get the full list of users"
+        },
+        "post": {
+          "$ref": "#/definitions/Endpoint<CreateUserRequest,User,structure-1619584020-912-953-1619584020-878-954-1619584020-839-955-1619584020-718-959-1619584020-706-960-1619584020-591-1729-1619584020-0-1730>",
+          "description": "Create a new user"
+        }
+      },
+      "required": [
+        "get",
+        "post"
+      ],
+      "type": "object"
+    },
+    "/users/:userId": {
+      "additionalProperties": false,
+      "properties": {
+        "delete": {
+          "$ref": "#/definitions/Endpoint<structure-1619584020-1274-1276-1619584020-1264-1283-1619584020-1252-1284-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730,User>"
+        },
+        "get": {
+          "$ref": "#/definitions/GetEndpoint<User,structure-1619584020-1009-1030-1619584020-991-1031-1619584020-982-1032-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730>"
+        },
+        "patch": {
+          "$ref": "#/definitions/Endpoint<alias-731470504-72960-73056-731470504-0-217694<def-alias-1619584020-201-306-1619584020-0-1730>,User>",
+          "description": "Edit an existing user"
+        },
+        "put": {
+          "$ref": "#/definitions/Endpoint<structure-1619584020-1139-1233-1619584020-1129-1251-1619584020-1120-1252-1619584020-980-1288-1619584020-960-1289-1619584020-591-1729-1619584020-0-1730,User>"
+        }
+      },
+      "required": [
+        "get",
+        "patch",
+        "put",
+        "delete"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "/random",
+    "/users",
+    "/users/:userId",
+    "/complex",
+    "/search"
+  ],
+  "type": "object"
 }
-

--- a/src/__tests__/api.ts
+++ b/src/__tests__/api.ts
@@ -5,9 +5,32 @@ export interface User {
   name: string;
   suffix?: string;
   age: number;
+  phoneNumbers: PhoneNumber[];
+  permanentAddress: Address;
 }
 
-export type CreateUserRequest = Pick<User, 'name' | 'age'>;
+export type CreateUserRequest = Pick<
+  User,
+  'name' | 'age' | 'phoneNumbers' | 'permanentAddress'
+>;
+
+export interface PhoneNumber {
+  number: string;
+  type: 'home' | 'work' | 'mobile' | null;
+}
+
+export interface Address {
+  street: string;
+  city: string;
+  state: string;
+  zip: string;
+  location: Location;
+}
+
+export interface Location {
+  latitude: number;
+  longitude: number;
+}
 
 export interface API {
   '/random': {
@@ -24,7 +47,10 @@ export interface API {
     get: GetEndpoint<User, {firstName?: string}>;
     /** Edit an existing user */
     patch: Endpoint<Partial<CreateUserRequest>, User>;
-    put: Endpoint<{name?: string; age?: number}, User>;
+    put: Endpoint<
+      {name?: string; age?: number; phoneNumbers?: PhoneNumber[]; permanentAddress?: Address},
+      User
+    >;
     delete: Endpoint<{}, User>;
   };
   '/complex': {

--- a/src/__tests__/openapi.test.ts
+++ b/src/__tests__/openapi.test.ts
@@ -2,9 +2,8 @@ import {apiSpecToOpenApi} from '../openapi';
 import apiSchemaJson from './api.schema.json';
 
 describe('Open API integration', () => {
-  const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '2.0'});
-
   it('should have the expected endpoints', () => {
+    const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '2.0'});
     expect(openApi).toMatchSnapshot('open-api');
   });
 
@@ -13,9 +12,8 @@ describe('Open API integration', () => {
 });
 
 describe('Open API V3', () => {
-  const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '3.0'});
-
   it('should have the expected endpoints', () => {
+    const openApi = apiSpecToOpenApi(apiSchemaJson, {version: '3.0'});
     expect(openApi).toMatchSnapshot('open-api-v3');
   });
 

--- a/src/__tests__/typed-request.test.ts
+++ b/src/__tests__/typed-request.test.ts
@@ -324,11 +324,43 @@ describe('typed requests', () => {
       const createUser = api.post('/users');
 
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});
-      const newUser = await createUser({}, {name: 'Fred', age: 42});
-      //    ^? const newUser: User
+      const newUser = await createUser(
+        //    ^? const newUser: User
+
+        {},
+        {
+          name: 'Fred',
+          age: 42,
+          phoneNumbers: [],
+          permanentAddress: {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'CA',
+            zip: '12345',
+            location: {
+              latitude: 37.774929,
+              longitude: -122.419416,
+            },
+          },
+        },
+      );
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {
+        name: 'Fred',
+        age: 42,
+        phoneNumbers: [],
+        permanentAddress: {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'CA',
+          zip: '12345',
+          location: {
+            latitude: 37.774929,
+            longitude: -122.419416,
+          },
+        },
+      });
     });
 
     it('should generate POST requests with query parameters', async () => {
@@ -338,13 +370,42 @@ describe('typed requests', () => {
       const createUser = api.post('/users');
 
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});
-      const newUser = await createUser({}, {name: 'Fred', age: 42}, {suffix: 'sr'});
-      //    ^? const newUser: User
+      const newUser = await createUser(
+        //    ^? const newUser: User
+        {},
+        {
+          name: 'Fred',
+          age: 42,
+          phoneNumbers: [],
+          permanentAddress: {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'CA',
+            zip: '12345',
+            location: {
+              latitude: 37.774929,
+              longitude: -122.419416,
+            },
+          },
+        },
+        {suffix: 'sr'},
+      );
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
       expect(mockFetcher).toHaveBeenCalledWith('/users?suffix=sr', 'post', {
         name: 'Fred',
         age: 42,
+        phoneNumbers: [],
+        permanentAddress: {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'CA',
+          zip: '12345',
+          location: {
+            latitude: 37.774929,
+            longitude: -122.419416,
+          },
+        },
       });
     });
 
@@ -374,11 +435,42 @@ describe('typed requests', () => {
       const createUser = api.request('post', '/users');
 
       mockFetcher.mockReturnValueOnce({id: 'fred', name: 'Fred', age: 42});
-      const newUser = await createUser({}, {name: 'Fred', age: 42});
-      //    ^? const newUser: User
+      const newUser = await createUser(
+        //    ^? const newUser: User
+        {},
+        {
+          name: 'Fred',
+          age: 42,
+          phoneNumbers: [],
+          permanentAddress: {
+            street: '123 Main St',
+            city: 'Anytown',
+            state: 'CA',
+            zip: '12345',
+            location: {
+              latitude: 37.774929,
+              longitude: -122.419416,
+            },
+          },
+        },
+      );
       expect(newUser).toEqual({id: 'fred', name: 'Fred', age: 42});
       expect(mockFetcher).toHaveBeenCalledTimes(1);
-      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {name: 'Fred', age: 42});
+      expect(mockFetcher).toHaveBeenCalledWith('/users', 'post', {
+        name: 'Fred',
+        age: 42,
+        phoneNumbers: [],
+        permanentAddress: {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'CA',
+          zip: '12345',
+          location: {
+            latitude: 37.774929,
+            longitude: -122.419416,
+          },
+        },
+      });
     });
 
     it('should accept readonly objects in POST requests', async () => {

--- a/src/__tests__/typed-router.test.ts
+++ b/src/__tests__/typed-router.test.ts
@@ -17,11 +17,33 @@ test('TypedRouter', async () => {
       id: 'fred',
       name: 'Fred',
       age: 42,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
     },
     {
       id: 'wilma',
       name: 'Wilma',
       age: 41,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
     },
   ];
 
@@ -85,6 +107,8 @@ test('TypedRouter', async () => {
       // ^? const body: {
       //        name?: string;
       //        age?: number;
+      //        phoneNumbers?: PhoneNumber[];
+      //        permanentAddress?: Address;
       //    }
 
       const {userId} = pathParams;
@@ -116,6 +140,10 @@ test('TypedRouter', async () => {
     return users[0];
   });
 
+  router.get('/search', async (_, {query: {numResults}}) => {
+    return {users: users.slice(0, numResults)};
+  });
+
   const api = request(app);
 
   const responseAllUsers = await api.get('/users').expect(200);
@@ -128,7 +156,22 @@ test('TypedRouter', async () => {
   expect(responseMinAge.body).toEqual({users: [users[0]]});
 
   const fredResponse = await api.get('/users/fred').expect(200);
-  expect(fredResponse.body).toEqual({id: 'fred', name: 'Fred', age: 42});
+  expect(fredResponse.body).toEqual({
+    id: 'fred',
+    name: 'Fred',
+    age: 42,
+    phoneNumbers: [],
+    permanentAddress: {
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zip: '12345',
+      location: {
+        latitude: 37.774929,
+        longitude: -122.419416,
+      },
+    },
+  });
 
   await api.get('/users/pebbles').expect(404, {error: 'No such user pebbles'});
 
@@ -139,17 +182,57 @@ test('TypedRouter', async () => {
     .send({age: 42})
     .set('Accept', 'application/json')
     .expect(200);
-  expect(responseNewWilma.body).toEqual({id: 'wilma', name: 'Wilma', age: 42});
+  expect(responseNewWilma.body).toEqual({
+    id: 'wilma',
+    name: 'Wilma',
+    age: 42,
+    phoneNumbers: [],
+    permanentAddress: {
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zip: '12345',
+      location: {
+        latitude: 37.774929,
+        longitude: -122.419416,
+      },
+    },
+  });
 
   const pebblesResponse = await api
     .post('/users')
     .set('Accept', 'application/json')
-    .send({name: 'Pebbles', age: 2})
+    .send({
+      name: 'Pebbles',
+      age: 2,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
+    })
     .expect(201);
   expect(pebblesResponse.body).toEqual({
     id: 'id',
     name: 'Pebbles',
     age: 2,
+    phoneNumbers: [],
+    permanentAddress: {
+      street: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zip: '12345',
+      location: {
+        latitude: 37.774929,
+        longitude: -122.419416,
+      },
+    },
   });
 
   await api.get('/users/id').expect(200);
@@ -159,7 +242,20 @@ test('TypedRouter', async () => {
   // Request validation tests
   await api
     .post('/users')
-    .send({age: 42})
+    .send({
+      age: 42,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
+    })
     .set('Accept', 'application/json')
     .expect(400)
     .expect(response => {
@@ -216,13 +312,45 @@ test('TypedRouter', async () => {
 
   await api
     .post('/complex')
-    .send({user: {id: 'id', name: 'name', age: 42}})
+    .send({
+      user: {
+        id: 'id',
+        name: 'name',
+        age: 42,
+        phoneNumbers: [],
+        permanentAddress: {
+          street: '123 Main St',
+          city: 'Anytown',
+          state: 'CA',
+          zip: '12345',
+          location: {
+            latitude: 37.774929,
+            longitude: -122.419416,
+          },
+        },
+      },
+    })
     .set('Accept', 'application/json')
     .expect(200);
 
   await api
     .patch('/complex')
-    .send({id: 'id', name: 'name', age: 42})
+    .send({
+      id: 'id',
+      name: 'name',
+      age: 42,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
+    })
     .set('Accept', 'application/json')
     .expect(200);
 
@@ -299,6 +427,17 @@ test('Throwing HTTPError should set status code', async () => {
       id: '1',
       name: 'John',
       age: 34,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
     };
   });
 
@@ -376,6 +515,17 @@ test('router middleware', async () => {
       id: '1',
       name: 'John',
       age: 34,
+      phoneNumbers: [],
+      permanentAddress: {
+        street: '123 Main St',
+        city: 'Anytown',
+        state: 'CA',
+        zip: '12345',
+        location: {
+          latitude: 37.774929,
+          longitude: -122.419416,
+        },
+      },
     };
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,6 +491,18 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -938,10 +950,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.5":
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
-  integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
+"@types/json-schema@^7.0.15":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/json-schema@^7.0.9":
   version "7.0.11"
@@ -962,6 +974,13 @@
   version "17.0.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.33.tgz#3c1879b276dc63e73030bb91165e62a4509cd506"
   integrity sha512-miWq2m2FiQZmaHfdZNcbpp9PuXg34W5JZ5CrJ/BaS70VuhoJENBEQybeiYSaPBRNq6KQGnjfEnc/F3PN++D+XQ==
+
+"@types/node@^22.15.30":
+  version "22.15.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.30.tgz#3a20431783e28dd0b0326f84ab386a2ec81d921d"
+  integrity sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/qs@*":
   version "6.9.5"
@@ -1224,6 +1243,11 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
+  integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -1242,6 +1266,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 anymatch@^3.0.3:
   version "3.1.2"
@@ -1457,7 +1486,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -1509,15 +1538,6 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-cliui@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
-  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^6.2.0"
-
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -1567,6 +1587,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
 
 component-emitter@^1.3.0:
   version "1.3.0"
@@ -1630,7 +1655,7 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
-cross-spawn@^7.0.2:
+cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1668,11 +1693,6 @@ debug@^4.3.1, debug@^4.3.4:
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
-
-decamelize@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 dedent@^1.0.0:
   version "1.5.3"
@@ -1733,6 +1753,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1764,6 +1789,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2126,6 +2156,14 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
@@ -2184,7 +2222,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1, get-caller-file@^2.0.5:
+get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -2213,6 +2251,18 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
+glob@^11.0.1:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-11.0.2.tgz#3261e3897bbc603030b041fd77ba636022d51ce0"
+  integrity sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^4.0.1"
+    minimatch "^10.0.0"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^2.0.0"
+
 glob@^7.1.3, glob@^7.1.4:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.2.tgz#29deb38e1ef90f132d5958abe9c3ee8e87f3c318"
@@ -2222,18 +2272,6 @@ glob@^7.1.3, glob@^7.1.4:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@~7.1.6:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -2482,6 +2520,13 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jackspeak@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.1.1.tgz#96876030f450502047fc7e8c7fcf8ce8124e43ae"
+  integrity sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
 
 jake@^10.8.5:
   version "10.9.2"
@@ -2921,13 +2966,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
-  dependencies:
-    jsonify "~0.0.0"
-
 json5@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
@@ -2946,11 +2984,6 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-  integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -3005,6 +3038,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lru-cache@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
+  integrity sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -3111,6 +3149,13 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+minimatch@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
+  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -3124,6 +3169,11 @@ minimatch@^5.0.1:
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
   dependencies:
     brace-expansion "^2.0.1"
+
+minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -3243,6 +3293,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3284,6 +3339,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.0.tgz#9f052289f23ad8bf9397a2a0425e7b8615c58580"
+  integrity sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -3461,11 +3524,6 @@ require-from-string@^2.0.2:
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-main-filename@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
-  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -3526,6 +3584,11 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-stable-stringify@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -3582,11 +3645,6 @@ serve-static@1.14.2:
     parseurl "~1.3.3"
     send "0.17.2"
 
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
-  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -3613,6 +3671,11 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -3662,6 +3725,15 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -3671,6 +3743,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -3678,12 +3759,26 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -3808,10 +3903,29 @@ ts-jest@^29.3.2:
     type-fest "^4.39.1"
     yargs-parser "^21.1.1"
 
+ts-json-schema-generator@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ts-json-schema-generator/-/ts-json-schema-generator-2.4.0.tgz#01b9682fc8a275b8c9b91cb60c964875a44637f1"
+  integrity sha512-HbmNsgs58CfdJq0gpteRTxPXG26zumezOs+SB9tgky6MpqiFgQwieCn2MW70+sxpHouZ/w9LW0V6L4ZQO4y1Ug==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+    commander "^13.1.0"
+    glob "^11.0.1"
+    json5 "^2.2.3"
+    normalize-path "^3.0.0"
+    safe-stable-stringify "^2.5.0"
+    tslib "^2.8.1"
+    typescript "^5.8.2"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -3855,26 +3969,15 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript-json-schema@^0.43.0:
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/typescript-json-schema/-/typescript-json-schema-0.43.0.tgz#8bd9c832f1f15f006ff933907ce192222fdfd92f"
-  integrity sha512-4c9IMlIlHYJiQtzL1gh2nIPJEjBgJjDUs50gsnnc+GFyDSK1oFM3uQIBSVosiuA/4t6LSAXDS9vTdqbQC6EcgA==
-  dependencies:
-    "@types/json-schema" "^7.0.5"
-    glob "~7.1.6"
-    json-stable-stringify "^1.0.1"
-    typescript "~4.0.2"
-    yargs "^15.4.1"
-
-typescript@5:
+typescript@5, typescript@^5.8.2:
   version "5.8.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
-typescript@~4.0.2:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
-  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -3932,11 +4035,6 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -3949,10 +4047,10 @@ word-wrap@^1.2.5:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -3967,6 +4065,15 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -3979,11 +4086,6 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
-
-y18n@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
-  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 y18n@^5.0.5:
   version "5.0.8"
@@ -4000,14 +4102,6 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@^18.1.2:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^21.0.0:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
@@ -4017,23 +4111,6 @@ yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
-yargs@^15.4.1:
-  version "15.4.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
-  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
-  dependencies:
-    cliui "^6.0.0"
-    decamelize "^1.2.0"
-    find-up "^4.1.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^4.2.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^18.1.2"
 
 yargs@^17.3.1:
   version "17.5.0"


### PR DESCRIPTION
This PR is giant because it fixes a bunch of bugs:

- First off, there's a bug where OpenAPI conversion code for v3 is not handling nested types and nullable types properly.
- While trying to fix that bug, I came across the fact that ts-json-schema is now outdated with the rest of the codebase. I had to upgrade it, but after upgrading I ran into https://github.com/YousefED/typescript-json-schema/issues/387 -- it's frustrating that after many years, there was no fix for such a critical issue. So I ended up having to replace this package wholesale with https://github.com/vega/ts-json-schema-generator. This works, but it has a few divergence (that still results in correct typing--it's just that typescript-json-schema has a tendency to hoist types that crosswalk was relying upon)